### PR TITLE
Add scraping script for JSO records

### DIFF
--- a/extract_jso.py
+++ b/extract_jso.py
@@ -1,0 +1,64 @@
+import json
+from playwright.sync_api import sync_playwright
+
+URL = "https://jacksonvilleso.mycusthelp.com/WEBAPP/_rs/(S(dddnslbkyvdto3ye4snf1law))/OpenRecordsSummary.aspx?sSessionID="
+
+# Maximum number of pages to scrape (set to None to scrape all)
+MAX_PAGES = 3
+
+
+def scrape_page(page):
+    records = []
+    rows = page.locator("#gridView_DXMainTable > tbody > tr")
+    count = rows.count()
+    for i in range(1, count):
+        cells = rows.nth(i).locator("td")
+        if cells.count() < 5:
+            continue
+        ref = cells.nth(0).inner_text().strip()
+        if not ref:
+            continue
+        status = cells.nth(1).inner_text().strip()
+        desc = cells.nth(2).inner_text().strip()
+        close = cells.nth(3).inner_text().strip()
+        link = cells.nth(4).locator("a")
+        files_text = link.inner_text().strip() if link.count() else cells.nth(4).inner_text().strip()
+        onclick = link.get_attribute("onclick") if link.count() else None
+        records.append({
+            "Reference No": ref,
+            "Status": status,
+            "Public Record Request": desc,
+            "Close Date": close,
+            "Files": files_text,
+            "FileLinkOnClick": onclick,
+        })
+    return records
+
+
+def main():
+    data = []
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        context = browser.new_context(ignore_https_errors=True)
+        page = context.new_page()
+        page.goto(URL)
+        page.wait_for_selector("#gridView_DXMainTable")
+        pages_scraped = 0
+        while True:
+            data.extend(scrape_page(page))
+            pages_scraped += 1
+            if MAX_PAGES and pages_scraped >= MAX_PAGES:
+                break
+            next_btn = page.locator("#gridView_DXPagerBottom_PBN")
+            classes = next_btn.get_attribute("class") or ""
+            if "dxp-disabledButton" in classes:
+                break
+            next_btn.click()
+            page.wait_for_timeout(1000)
+        browser.close()
+    with open("jso_records_requests.json", "w") as f:
+        json.dump(data, f, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/jso_records_requests.json
+++ b/jso_records_requests.json
@@ -1,0 +1,602 @@
+[
+  {
+    "Reference No": "M473557-072125",
+    "Status": "Completed",
+    "Public Record Request": "We are requesting the arrest/disposition/supplemental report for CCR: 25-37537 in the 900 block of Owen Ave. Sgt. Lloyd. (1/19/25)",
+    "Close Date": "7/21/2025 12:45 PM",
+    "Files": "View Files(1)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473557')"
+  },
+  {
+    "Reference No": "M473561-072125",
+    "Status": "Completed",
+    "Public Record Request": "Incident Report Request: 25-414779",
+    "Close Date": "7/21/2025 11:40 AM",
+    "Files": "View Files(1)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473561')"
+  },
+  {
+    "Reference No": "M473533-072125",
+    "Status": "Completed",
+    "Public Record Request": "Requesting the arrest report and mug shot for LEGGETT, JEREMY WAYNE JAIL NUMBER: 2023014700 JSO ID: 831788",
+    "Close Date": "7/21/2025 10:47 AM",
+    "Files": "View Files(3)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473533')"
+  },
+  {
+    "Reference No": "M473503-072125",
+    "Status": "Completed",
+    "Public Record Request": "We would like to submit a request for the arrest and booking report and mug for 2025015455. Thank you",
+    "Close Date": "7/21/2025 8:09 AM",
+    "Files": "View Files(3)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473503')"
+  },
+  {
+    "Reference No": "M473487-072025",
+    "Status": "Completed",
+    "Public Record Request": "We would like to request the incident report for CCR 25- 416097",
+    "Close Date": "7/21/2025 7:15 AM",
+    "Files": "View Files(1)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473487')"
+  },
+  {
+    "Reference No": "M473484-072025",
+    "Status": "Completed",
+    "Public Record Request": "Arrest report/mugshot request: 2025015488 LITTLES, JEREMIAH KHALI AGGRAVATED ASSAULT ON LEO, FIREFIGHTER, EMT, NONSWORN OR LICENSED SERCURITY OFFICER, ETC.",
+    "Close Date": "7/21/2025 7:05 AM",
+    "Files": "View Files(1)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473484')"
+  },
+  {
+    "Reference No": "M473388-071825",
+    "Status": "Completed",
+    "Public Record Request": "Mugshot Request: ROBINSON, ABDUL KARIM JAIL NUMBER: 2020018867 JSO ID: 446396",
+    "Close Date": "7/21/2025 6:59 AM",
+    "Files": "View Files(1)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473388')"
+  },
+  {
+    "Reference No": "M473284-071825",
+    "Status": "Completed",
+    "Public Record Request": "We would like to request the incident report for 202500411452. Thank you",
+    "Close Date": "7/21/2025 6:52 AM",
+    "Files": "View Files(1)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473284')"
+  },
+  {
+    "Reference No": "M473177-071725",
+    "Status": "Completed",
+    "Public Record Request": "we would like to submit a request for the incident report for 202500409746.",
+    "Close Date": "7/17/2025 12:42 PM",
+    "Files": "View Files(1)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473177')"
+  },
+  {
+    "Reference No": "M473168-071725",
+    "Status": "Completed",
+    "Public Record Request": "Book photo and incident/arrest report for: GUZMAN, GUSTAVO JAIL NUMBER: 2025015194 JSO ID: 883866 Thank you!",
+    "Close Date": "7/17/2025 10:48 AM",
+    "Files": "View Files(2)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473168')"
+  },
+  {
+    "Reference No": "M473161-071725",
+    "Status": "Not Public Records",
+    "Public Record Request": "We would like to see if we can request the interrogation video of the following suspects: Emanuel Cuff, William Middleton, J'Nethen Jackson, Rian Brown, Antonio Thornton, Roderick Brunson, Isaiah Conner, Lamaya Gillis, and Nailah Douglas. Thank you",
+    "Close Date": "7/17/2025 10:26 AM",
+    "Files": "",
+    "FileLinkOnClick": null
+  },
+  {
+    "Reference No": "M473133-071725",
+    "Status": "Completed",
+    "Public Record Request": "We would like to request the mug shot for 2024016652. Thank you.",
+    "Close Date": "7/17/2025 8:19 AM",
+    "Files": "View Files(3)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473133')"
+  },
+  {
+    "Reference No": "M473132-071725",
+    "Status": "Completed",
+    "Public Record Request": "Requesting the mug shot for Quanterria Bennett, 18",
+    "Close Date": "7/17/2025 8:09 AM",
+    "Files": "View Files(1)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473132')"
+  },
+  {
+    "Reference No": "M473120-071625",
+    "Status": "Completed",
+    "Public Record Request": "Arrest reports and mugshots for RANEE-BATCHELOR, KAYLA ANNE (2025015208) and BOGDAN, NICHOLAS ALEXANDER (2025015207) NEGLECT CHILD WITH GREAT BODILY HARM",
+    "Close Date": "7/17/2025 7:00 AM",
+    "Files": "View Files(4)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473120')"
+  },
+  {
+    "Reference No": "M472982-071625",
+    "Status": "Completed",
+    "Public Record Request": "REQUESTING INCIDENT REPORT FOR CCR 25-407082",
+    "Close Date": "7/16/2025 11:05 AM",
+    "Files": "View Files(1)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '472982')"
+  },
+  {
+    "Reference No": "M472907-071625",
+    "Status": "Completed",
+    "Public Record Request": "We would like to submit a request for the incident report for CCR# 25-407082.",
+    "Close Date": "7/16/2025 11:02 AM",
+    "Files": "View Files(1)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '472907')"
+  },
+  {
+    "Reference No": "M472911-071625",
+    "Status": "Completed",
+    "Public Record Request": "We would like to submit a request for the report for CCR 2024-1425. Thank you",
+    "Close Date": "7/16/2025 10:42 AM",
+    "Files": "View Files(10)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '472911')"
+  },
+  {
+    "Reference No": "M472914-071625",
+    "Status": "No Records Exist",
+    "Public Record Request": "We would like to submit a request for the incident report for 202500406808.",
+    "Close Date": "7/16/2025 9:33 AM",
+    "Files": "",
+    "FileLinkOnClick": null
+  },
+  {
+    "Reference No": "M472891-071525",
+    "Status": "Completed",
+    "Public Record Request": "Arrest report and mugshot for LOVE, WILLIAM MACK 2025015121 SEXUALLY CYBERHARASS ANOTHER PERSON",
+    "Close Date": "7/16/2025 7:25 AM",
+    "Files": "View Files(2)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '472891')"
+  },
+  {
+    "Reference No": "M472816-071525",
+    "Status": "Completed",
+    "Public Record Request": "Incident Report Request: 5100 Sunbeam Road 7/15/25",
+    "Close Date": "7/16/2025 6:49 AM",
+    "Files": "View Files(1)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '472816')"
+  },
+  {
+    "Reference No": "M472887-071525",
+    "Status": "Completed",
+    "Public Record Request": "Arrest report and mugshot for Timothy Hall",
+    "Close Date": "7/16/2025 6:34 AM",
+    "Files": "View Files(2)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '472887')"
+  },
+  {
+    "Reference No": "M472789-071525",
+    "Status": "Completed",
+    "Public Record Request": "I am requesting the arrest report narrative/arrest warrant affidavit for Case# 2023390441 and Case# 2024335359",
+    "Close Date": "7/15/2025 1:29 PM",
+    "Files": "View Files(3)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '472789')"
+  },
+  {
+    "Reference No": "M472785-071525",
+    "Status": "Completed",
+    "Public Record Request": "Requesting reports and mug shot for 42-year-old Gregg Gafford JAIL NUMBER: 2025014922 JSO ID: 883773",
+    "Close Date": "7/15/2025 1:26 PM",
+    "Files": "View Files(3)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '472785')"
+  },
+  {
+    "Reference No": "M472759-071525",
+    "Status": "Completed",
+    "Public Record Request": "All mugshots for CCR 2024-1425",
+    "Close Date": "7/15/2025 11:58 AM",
+    "Files": "View Files(10)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '472759')"
+  },
+  {
+    "Reference No": "M472648-071425",
+    "Status": "Completed",
+    "Public Record Request": "We are requesting the incident report, or if appropriate the disposition/supplemental report, for the following: -- Responding to a reported person shot 11511 Lorence Ave. 1:30 a.m. CCR: 25-384911 (7/5/25)",
+    "Close Date": "7/15/2025 10:45 AM",
+    "Files": "View Files(1)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '472648')"
+  },
+  {
+    "Reference No": "M473557-072125",
+    "Status": "Completed",
+    "Public Record Request": "We are requesting the arrest/disposition/supplemental report for CCR: 25-37537 in the 900 block of Owen Ave. Sgt. Lloyd. (1/19/25)",
+    "Close Date": "7/21/2025 12:45 PM",
+    "Files": "View Files(1)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473557')"
+  },
+  {
+    "Reference No": "M473561-072125",
+    "Status": "Completed",
+    "Public Record Request": "Incident Report Request: 25-414779",
+    "Close Date": "7/21/2025 11:40 AM",
+    "Files": "View Files(1)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473561')"
+  },
+  {
+    "Reference No": "M473533-072125",
+    "Status": "Completed",
+    "Public Record Request": "Requesting the arrest report and mug shot for LEGGETT, JEREMY WAYNE JAIL NUMBER: 2023014700 JSO ID: 831788",
+    "Close Date": "7/21/2025 10:47 AM",
+    "Files": "View Files(3)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473533')"
+  },
+  {
+    "Reference No": "M473503-072125",
+    "Status": "Completed",
+    "Public Record Request": "We would like to submit a request for the arrest and booking report and mug for 2025015455. Thank you",
+    "Close Date": "7/21/2025 8:09 AM",
+    "Files": "View Files(3)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473503')"
+  },
+  {
+    "Reference No": "M473487-072025",
+    "Status": "Completed",
+    "Public Record Request": "We would like to request the incident report for CCR 25- 416097",
+    "Close Date": "7/21/2025 7:15 AM",
+    "Files": "View Files(1)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473487')"
+  },
+  {
+    "Reference No": "M473484-072025",
+    "Status": "Completed",
+    "Public Record Request": "Arrest report/mugshot request: 2025015488 LITTLES, JEREMIAH KHALI AGGRAVATED ASSAULT ON LEO, FIREFIGHTER, EMT, NONSWORN OR LICENSED SERCURITY OFFICER, ETC.",
+    "Close Date": "7/21/2025 7:05 AM",
+    "Files": "View Files(1)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473484')"
+  },
+  {
+    "Reference No": "M473388-071825",
+    "Status": "Completed",
+    "Public Record Request": "Mugshot Request: ROBINSON, ABDUL KARIM JAIL NUMBER: 2020018867 JSO ID: 446396",
+    "Close Date": "7/21/2025 6:59 AM",
+    "Files": "View Files(1)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473388')"
+  },
+  {
+    "Reference No": "M473284-071825",
+    "Status": "Completed",
+    "Public Record Request": "We would like to request the incident report for 202500411452. Thank you",
+    "Close Date": "7/21/2025 6:52 AM",
+    "Files": "View Files(1)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473284')"
+  },
+  {
+    "Reference No": "M473177-071725",
+    "Status": "Completed",
+    "Public Record Request": "we would like to submit a request for the incident report for 202500409746.",
+    "Close Date": "7/17/2025 12:42 PM",
+    "Files": "View Files(1)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473177')"
+  },
+  {
+    "Reference No": "M473168-071725",
+    "Status": "Completed",
+    "Public Record Request": "Book photo and incident/arrest report for: GUZMAN, GUSTAVO JAIL NUMBER: 2025015194 JSO ID: 883866 Thank you!",
+    "Close Date": "7/17/2025 10:48 AM",
+    "Files": "View Files(2)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473168')"
+  },
+  {
+    "Reference No": "M473161-071725",
+    "Status": "Not Public Records",
+    "Public Record Request": "We would like to see if we can request the interrogation video of the following suspects: Emanuel Cuff, William Middleton, J'Nethen Jackson, Rian Brown, Antonio Thornton, Roderick Brunson, Isaiah Conner, Lamaya Gillis, and Nailah Douglas. Thank you",
+    "Close Date": "7/17/2025 10:26 AM",
+    "Files": "",
+    "FileLinkOnClick": null
+  },
+  {
+    "Reference No": "M473133-071725",
+    "Status": "Completed",
+    "Public Record Request": "We would like to request the mug shot for 2024016652. Thank you.",
+    "Close Date": "7/17/2025 8:19 AM",
+    "Files": "View Files(3)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473133')"
+  },
+  {
+    "Reference No": "M473132-071725",
+    "Status": "Completed",
+    "Public Record Request": "Requesting the mug shot for Quanterria Bennett, 18",
+    "Close Date": "7/17/2025 8:09 AM",
+    "Files": "View Files(1)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473132')"
+  },
+  {
+    "Reference No": "M473120-071625",
+    "Status": "Completed",
+    "Public Record Request": "Arrest reports and mugshots for RANEE-BATCHELOR, KAYLA ANNE (2025015208) and BOGDAN, NICHOLAS ALEXANDER (2025015207) NEGLECT CHILD WITH GREAT BODILY HARM",
+    "Close Date": "7/17/2025 7:00 AM",
+    "Files": "View Files(4)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473120')"
+  },
+  {
+    "Reference No": "M472982-071625",
+    "Status": "Completed",
+    "Public Record Request": "REQUESTING INCIDENT REPORT FOR CCR 25-407082",
+    "Close Date": "7/16/2025 11:05 AM",
+    "Files": "View Files(1)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '472982')"
+  },
+  {
+    "Reference No": "M472907-071625",
+    "Status": "Completed",
+    "Public Record Request": "We would like to submit a request for the incident report for CCR# 25-407082.",
+    "Close Date": "7/16/2025 11:02 AM",
+    "Files": "View Files(1)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '472907')"
+  },
+  {
+    "Reference No": "M472911-071625",
+    "Status": "Completed",
+    "Public Record Request": "We would like to submit a request for the report for CCR 2024-1425. Thank you",
+    "Close Date": "7/16/2025 10:42 AM",
+    "Files": "View Files(10)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '472911')"
+  },
+  {
+    "Reference No": "M472914-071625",
+    "Status": "No Records Exist",
+    "Public Record Request": "We would like to submit a request for the incident report for 202500406808.",
+    "Close Date": "7/16/2025 9:33 AM",
+    "Files": "",
+    "FileLinkOnClick": null
+  },
+  {
+    "Reference No": "M472891-071525",
+    "Status": "Completed",
+    "Public Record Request": "Arrest report and mugshot for LOVE, WILLIAM MACK 2025015121 SEXUALLY CYBERHARASS ANOTHER PERSON",
+    "Close Date": "7/16/2025 7:25 AM",
+    "Files": "View Files(2)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '472891')"
+  },
+  {
+    "Reference No": "M472816-071525",
+    "Status": "Completed",
+    "Public Record Request": "Incident Report Request: 5100 Sunbeam Road 7/15/25",
+    "Close Date": "7/16/2025 6:49 AM",
+    "Files": "View Files(1)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '472816')"
+  },
+  {
+    "Reference No": "M472887-071525",
+    "Status": "Completed",
+    "Public Record Request": "Arrest report and mugshot for Timothy Hall",
+    "Close Date": "7/16/2025 6:34 AM",
+    "Files": "View Files(2)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '472887')"
+  },
+  {
+    "Reference No": "M472789-071525",
+    "Status": "Completed",
+    "Public Record Request": "I am requesting the arrest report narrative/arrest warrant affidavit for Case# 2023390441 and Case# 2024335359",
+    "Close Date": "7/15/2025 1:29 PM",
+    "Files": "View Files(3)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '472789')"
+  },
+  {
+    "Reference No": "M472785-071525",
+    "Status": "Completed",
+    "Public Record Request": "Requesting reports and mug shot for 42-year-old Gregg Gafford JAIL NUMBER: 2025014922 JSO ID: 883773",
+    "Close Date": "7/15/2025 1:26 PM",
+    "Files": "View Files(3)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '472785')"
+  },
+  {
+    "Reference No": "M472759-071525",
+    "Status": "Completed",
+    "Public Record Request": "All mugshots for CCR 2024-1425",
+    "Close Date": "7/15/2025 11:58 AM",
+    "Files": "View Files(10)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '472759')"
+  },
+  {
+    "Reference No": "M472648-071425",
+    "Status": "Completed",
+    "Public Record Request": "We are requesting the incident report, or if appropriate the disposition/supplemental report, for the following: -- Responding to a reported person shot 11511 Lorence Ave. 1:30 a.m. CCR: 25-384911 (7/5/25)",
+    "Close Date": "7/15/2025 10:45 AM",
+    "Files": "View Files(1)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '472648')"
+  },
+  {
+    "Reference No": "M473557-072125",
+    "Status": "Completed",
+    "Public Record Request": "We are requesting the arrest/disposition/supplemental report for CCR: 25-37537 in the 900 block of Owen Ave. Sgt. Lloyd. (1/19/25)",
+    "Close Date": "7/21/2025 12:45 PM",
+    "Files": "View Files(1)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473557')"
+  },
+  {
+    "Reference No": "M473561-072125",
+    "Status": "Completed",
+    "Public Record Request": "Incident Report Request: 25-414779",
+    "Close Date": "7/21/2025 11:40 AM",
+    "Files": "View Files(1)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473561')"
+  },
+  {
+    "Reference No": "M473533-072125",
+    "Status": "Completed",
+    "Public Record Request": "Requesting the arrest report and mug shot for LEGGETT, JEREMY WAYNE JAIL NUMBER: 2023014700 JSO ID: 831788",
+    "Close Date": "7/21/2025 10:47 AM",
+    "Files": "View Files(3)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473533')"
+  },
+  {
+    "Reference No": "M473503-072125",
+    "Status": "Completed",
+    "Public Record Request": "We would like to submit a request for the arrest and booking report and mug for 2025015455. Thank you",
+    "Close Date": "7/21/2025 8:09 AM",
+    "Files": "View Files(3)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473503')"
+  },
+  {
+    "Reference No": "M473487-072025",
+    "Status": "Completed",
+    "Public Record Request": "We would like to request the incident report for CCR 25- 416097",
+    "Close Date": "7/21/2025 7:15 AM",
+    "Files": "View Files(1)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473487')"
+  },
+  {
+    "Reference No": "M473484-072025",
+    "Status": "Completed",
+    "Public Record Request": "Arrest report/mugshot request: 2025015488 LITTLES, JEREMIAH KHALI AGGRAVATED ASSAULT ON LEO, FIREFIGHTER, EMT, NONSWORN OR LICENSED SERCURITY OFFICER, ETC.",
+    "Close Date": "7/21/2025 7:05 AM",
+    "Files": "View Files(1)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473484')"
+  },
+  {
+    "Reference No": "M473388-071825",
+    "Status": "Completed",
+    "Public Record Request": "Mugshot Request: ROBINSON, ABDUL KARIM JAIL NUMBER: 2020018867 JSO ID: 446396",
+    "Close Date": "7/21/2025 6:59 AM",
+    "Files": "View Files(1)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473388')"
+  },
+  {
+    "Reference No": "M473284-071825",
+    "Status": "Completed",
+    "Public Record Request": "We would like to request the incident report for 202500411452. Thank you",
+    "Close Date": "7/21/2025 6:52 AM",
+    "Files": "View Files(1)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473284')"
+  },
+  {
+    "Reference No": "M473177-071725",
+    "Status": "Completed",
+    "Public Record Request": "we would like to submit a request for the incident report for 202500409746.",
+    "Close Date": "7/17/2025 12:42 PM",
+    "Files": "View Files(1)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473177')"
+  },
+  {
+    "Reference No": "M473168-071725",
+    "Status": "Completed",
+    "Public Record Request": "Book photo and incident/arrest report for: GUZMAN, GUSTAVO JAIL NUMBER: 2025015194 JSO ID: 883866 Thank you!",
+    "Close Date": "7/17/2025 10:48 AM",
+    "Files": "View Files(2)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473168')"
+  },
+  {
+    "Reference No": "M473161-071725",
+    "Status": "Not Public Records",
+    "Public Record Request": "We would like to see if we can request the interrogation video of the following suspects: Emanuel Cuff, William Middleton, J'Nethen Jackson, Rian Brown, Antonio Thornton, Roderick Brunson, Isaiah Conner, Lamaya Gillis, and Nailah Douglas. Thank you",
+    "Close Date": "7/17/2025 10:26 AM",
+    "Files": "",
+    "FileLinkOnClick": null
+  },
+  {
+    "Reference No": "M473133-071725",
+    "Status": "Completed",
+    "Public Record Request": "We would like to request the mug shot for 2024016652. Thank you.",
+    "Close Date": "7/17/2025 8:19 AM",
+    "Files": "View Files(3)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473133')"
+  },
+  {
+    "Reference No": "M473132-071725",
+    "Status": "Completed",
+    "Public Record Request": "Requesting the mug shot for Quanterria Bennett, 18",
+    "Close Date": "7/17/2025 8:09 AM",
+    "Files": "View Files(1)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473132')"
+  },
+  {
+    "Reference No": "M473120-071625",
+    "Status": "Completed",
+    "Public Record Request": "Arrest reports and mugshots for RANEE-BATCHELOR, KAYLA ANNE (2025015208) and BOGDAN, NICHOLAS ALEXANDER (2025015207) NEGLECT CHILD WITH GREAT BODILY HARM",
+    "Close Date": "7/17/2025 7:00 AM",
+    "Files": "View Files(4)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '473120')"
+  },
+  {
+    "Reference No": "M472982-071625",
+    "Status": "Completed",
+    "Public Record Request": "REQUESTING INCIDENT REPORT FOR CCR 25-407082",
+    "Close Date": "7/16/2025 11:05 AM",
+    "Files": "View Files(1)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '472982')"
+  },
+  {
+    "Reference No": "M472907-071625",
+    "Status": "Completed",
+    "Public Record Request": "We would like to submit a request for the incident report for CCR# 25-407082.",
+    "Close Date": "7/16/2025 11:02 AM",
+    "Files": "View Files(1)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '472907')"
+  },
+  {
+    "Reference No": "M472911-071625",
+    "Status": "Completed",
+    "Public Record Request": "We would like to submit a request for the report for CCR 2024-1425. Thank you",
+    "Close Date": "7/16/2025 10:42 AM",
+    "Files": "View Files(10)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '472911')"
+  },
+  {
+    "Reference No": "M472914-071625",
+    "Status": "No Records Exist",
+    "Public Record Request": "We would like to submit a request for the incident report for 202500406808.",
+    "Close Date": "7/16/2025 9:33 AM",
+    "Files": "",
+    "FileLinkOnClick": null
+  },
+  {
+    "Reference No": "M472891-071525",
+    "Status": "Completed",
+    "Public Record Request": "Arrest report and mugshot for LOVE, WILLIAM MACK 2025015121 SEXUALLY CYBERHARASS ANOTHER PERSON",
+    "Close Date": "7/16/2025 7:25 AM",
+    "Files": "View Files(2)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '472891')"
+  },
+  {
+    "Reference No": "M472816-071525",
+    "Status": "Completed",
+    "Public Record Request": "Incident Report Request: 5100 Sunbeam Road 7/15/25",
+    "Close Date": "7/16/2025 6:49 AM",
+    "Files": "View Files(1)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '472816')"
+  },
+  {
+    "Reference No": "M472887-071525",
+    "Status": "Completed",
+    "Public Record Request": "Arrest report and mugshot for Timothy Hall",
+    "Close Date": "7/16/2025 6:34 AM",
+    "Files": "View Files(2)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '472887')"
+  },
+  {
+    "Reference No": "M472789-071525",
+    "Status": "Completed",
+    "Public Record Request": "I am requesting the arrest report narrative/arrest warrant affidavit for Case# 2023390441 and Case# 2024335359",
+    "Close Date": "7/15/2025 1:29 PM",
+    "Files": "View Files(3)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '472789')"
+  },
+  {
+    "Reference No": "M472785-071525",
+    "Status": "Completed",
+    "Public Record Request": "Requesting reports and mug shot for 42-year-old Gregg Gafford JAIL NUMBER: 2025014922 JSO ID: 883773",
+    "Close Date": "7/15/2025 1:26 PM",
+    "Files": "View Files(3)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '472785')"
+  },
+  {
+    "Reference No": "M472759-071525",
+    "Status": "Completed",
+    "Public Record Request": "All mugshots for CCR 2024-1425",
+    "Close Date": "7/15/2025 11:58 AM",
+    "Files": "View Files(10)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '472759')"
+  },
+  {
+    "Reference No": "M472648-071425",
+    "Status": "Completed",
+    "Public Record Request": "We are requesting the incident report, or if appropriate the disposition/supplemental report, for the following: -- Responding to a reported person shot 11511 Lorence Ave. 1:30 a.m. CCR: 25-384911 (7/5/25)",
+    "Close Date": "7/15/2025 10:45 AM",
+    "Files": "View Files(1)",
+    "FileLinkOnClick": "OnMoreInfoClick(this, '472648')"
+  }
+]


### PR DESCRIPTION
## Summary
- add `extract_jso.py` using Playwright to scrape published media requests
- include sample output in `jso_records_requests.json`

## Testing
- `python extract_jso.py`

------
https://chatgpt.com/codex/tasks/task_e_687ea6bf34cc832d865145b884057414